### PR TITLE
sync: use a more verbose system_core (loglevel 8)

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -553,7 +553,8 @@
   <project path="prebuilts/sdk" name="platform/prebuilts/sdk" groups="pdk" remote="aosp" />
   <project path="prebuilts/tools" name="platform/prebuilts/tools" groups="pdk,tools" remote="aosp" />
   <project path="sdk" name="platform/sdk" remote="aosp" />
-  <project path="system/core" name="CyanogenMod/android_system_core" groups="pdk" />
+  <!-- Use a more verbose version (loglevel8) -->
+  <project path="system/core" name="Alphapixels/android_system_core" groups="pdk" />
   <project path="system/extras" name="CyanogenMod/android_system_extras" groups="pdk" />
   <project path="system/extras/su" name="CyanogenMod/android_system_extras_su" />
   <project path="system/keymaster" name="CyanogenMod/android_system_keymaster" groups="pdk" />


### PR DESCRIPTION
We're having issues with init not starting system services according to 

> This is after starting by hand all the following services
> start sdcard
> start audiod
> start media
> etc...

So I thought it would be best while we debug we get some more verbose output by setting it from 3 -> 8. 
